### PR TITLE
Allow the admin to deactivate another admin

### DIFF
--- a/src/builders/userBuilder.ts
+++ b/src/builders/userBuilder.ts
@@ -15,6 +15,7 @@ export class User {
   public readonly role?: Role
   public readonly coach?: string
   public readonly googleId?: null | string
+  public readonly active?: boolean
 
   public constructor(data: PartialIUserWithRequiredId) {
     this.id = data.id
@@ -25,6 +26,7 @@ export class User {
     this.role = data.role
     this.coach = data.coach
     this.googleId = data.googleId
+    this.active = data.active
   }
 }
 
@@ -41,6 +43,7 @@ export class UserBuilder extends Builder<
     password: "$2a$10$qMiI0IyA/BCuHyjgqn/f8.IDjrqn7rMrHoH4LZmYoYdXlhWI8QGiu",
     role: Role.Trainee,
     coach: "My coach",
+    active: true,
   }
 
   constructor() {
@@ -91,6 +94,11 @@ export class UserBuilder extends Builder<
 
   public withCoach(coach: string): this {
     this.properties.coach = coach
+    return this
+  }
+
+  public withActive(active: boolean): this {
+    this.properties.active = active
     return this
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,6 @@
+import dotenv from "dotenv"
+dotenv.config()
+
 export const secret = process.env.ACCESS_TOKEN_KEY || ""
 
 export const ACCESS_TOKEN_EXPIRATION = "10h"

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from "express"
 import {
   getUsersSchema,
   ProfileSchema,
+  toggleActiveStatusSchema,
   updateUserSchema,
 } from "../validations/userValidation"
 import {
@@ -97,11 +98,7 @@ export const toggleUserActiveStatus = async (
     const userId = req.params.userId
     const { active } = req.body
 
-    if (typeof active !== "boolean") {
-      return res.status(400).json({
-        message: "Active status must be a boolean",
-      })
-    }
+    await toggleActiveStatusSchema.validateAsync({ active })
 
     // Get the user to check if they're an admin
     const targetUser = await getUserService({ _id: userId })

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -2,7 +2,6 @@ import { NextFunction, Request, Response } from "express"
 import {
   getUsersSchema,
   ProfileSchema,
-  toggleActiveStatusSchema,
   updateUserSchema,
 } from "../validations/userValidation"
 import {
@@ -96,9 +95,6 @@ export const toggleUserActiveStatus = async (
 ) => {
   try {
     const userId = req.params.userId
-    const { active } = req.body
-
-    await toggleActiveStatusSchema.validateAsync({ active })
 
     // Get the user to check if they're an admin
     const targetUser = await getUserService({ _id: userId })
@@ -108,8 +104,11 @@ export const toggleUserActiveStatus = async (
       })
     }
 
-    const user = await updateUserService(userId, { active })
-    return res.status(200).send(user)
+    const updatedUser = await updateUserService(userId, {
+      active: !targetUser.active,
+    })
+
+    return res.status(200).send(updatedUser)
   } catch (error) {
     return next(error)
   }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -10,6 +10,7 @@ import {
   getUsersService,
   updateUserService,
 } from "../services/userService"
+import { Role } from "../utils/types"
 
 export const getProfile = async (
   req: any,
@@ -82,6 +83,36 @@ export const deleteUser = async (
     const userId = req.params.userId
     await deleteUserService(userId)
     return res.status(200).send("User deleted successfully")
+  } catch (error) {
+    return next(error)
+  }
+}
+
+export const toggleUserActiveStatus = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const userId = req.params.userId
+    const { active } = req.body
+
+    if (typeof active !== "boolean") {
+      return res.status(400).json({
+        message: "Active status must be a boolean",
+      })
+    }
+
+    // Get the user to check if they're an admin
+    const targetUser = await getUserService({ _id: userId })
+    if (targetUser.role !== Role.Admin) {
+      return res.status(403).json({
+        message: "You can only activate/deactivate admin users",
+      })
+    }
+
+    const user = await updateUserService(userId, { active })
+    return res.status(200).send(user)
   } catch (error) {
     return next(error)
   }

--- a/src/middlewares/authenticate.ts
+++ b/src/middlewares/authenticate.ts
@@ -24,7 +24,18 @@ export const verifyJWT = (req: any, res: Response, next: NextFunction) => {
     }
 
     try {
-      req.user = await getUserService({ _id: decoded.id })
+      const user = await getUserService({ _id: decoded.id })
+
+      // Check if user is active
+      if (!user.active) {
+        return res.status(403).json({
+          type: "DeactivatedAccount",
+          errorMessage:
+            "Account was deactivated, please consult the admin for more information",
+        })
+      }
+
+      req.user = user
       return next()
     } catch (err) {
       return next(err)

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -13,6 +13,7 @@ export interface IUser extends Document {
   coach?: string
   googleId: null | string
   isOnWaitList?: boolean
+  active: boolean
 }
 
 const UserSchema = new Schema(
@@ -55,6 +56,10 @@ const UserSchema = new Schema(
       type: Boolean,
       default: false,
       required: false,
+    },
+    active: {
+      type: Boolean,
+      default: true,
     },
   },
   { timestamps: {} },

--- a/src/routes/userRoute.ts
+++ b/src/routes/userRoute.ts
@@ -5,6 +5,7 @@ import {
   deleteUser,
   getUsersController,
   updateUser,
+  toggleUserActiveStatus,
 } from "../controllers/userController"
 import { verifyJWT } from "../middlewares/authenticate"
 import { isAdmin } from "../middlewares/authorization"
@@ -16,5 +17,6 @@ router.get("/my-profile", verifyJWT, getProfile)
 router.patch("/my-profile", verifyJWT, updateProfile)
 router.patch("/:userId", verifyJWT, isAdmin, updateUser)
 router.delete("/:userId", deleteUser)
+router.patch("/:userId/status", verifyJWT, isAdmin, toggleUserActiveStatus)
 
 export default router

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -110,7 +110,7 @@ export const loginService = async (body: any) => {
     )
   }
 
-  if (user.active === false) {
+  if (!user.active) {
     throw new CustomError(
       NOT_ALLOWED,
       "Account was deactivated, please consult the admin for more information",
@@ -122,8 +122,6 @@ export const loginService = async (body: any) => {
   if (!match) {
     throw new CustomError(INVALID_CREDENTIAL, "Invalid credential", 401)
   }
-
-  console.log("ACCESS_TOKEN_KEY: ", secret)
 
   const accessToken = jwt.sign({ id: user._id }, secret, {
     expiresIn: ACCESS_TOKEN_EXPIRATION,
@@ -161,7 +159,7 @@ export const googleAuthService = async (token: string) => {
       )
     }
 
-    if (user.active === false) {
+    if (!user.active) {
       throw new CustomError(
         NOT_ALLOWED,
         "Account was deactivated, please consult the admin for more information",

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -123,6 +123,8 @@ export const loginService = async (body: any) => {
     throw new CustomError(INVALID_CREDENTIAL, "Invalid credential", 401)
   }
 
+  console.log("ACCESS_TOKEN_KEY: ", secret)
+
   const accessToken = jwt.sign({ id: user._id }, secret, {
     expiresIn: ACCESS_TOKEN_EXPIRATION,
   })

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -40,6 +40,7 @@ export const registerService = async (
     name,
     password: hashedPassword,
     verified: true,
+    active: true,
   })
 
   await sendEmail(createdUser.email, {
@@ -65,6 +66,7 @@ export const applicantRegisterService = async (body: any) => {
     name,
     userId: await generateUserIdService(),
     password: hashedPassword,
+    active: true,
   })
 
   await sendEmail(createdUser.email, {
@@ -105,6 +107,14 @@ export const loginService = async (body: any) => {
       NOT_ALLOWED,
       "Trainees are not allowed to login yet",
       409,
+    )
+  }
+
+  if (user.active === false) {
+    throw new CustomError(
+      NOT_ALLOWED,
+      "Account was deactivated, please consult the admin for more information",
+      403,
     )
   }
 
@@ -149,6 +159,14 @@ export const googleAuthService = async (token: string) => {
       )
     }
 
+    if (user.active === false) {
+      throw new CustomError(
+        NOT_ALLOWED,
+        "Account was deactivated, please consult the admin for more information",
+        403,
+      )
+    }
+
     const accessToken = jwt.sign({ id: user._id }, secret, {
       expiresIn: ACCESS_TOKEN_EXPIRATION,
     })
@@ -162,6 +180,7 @@ export const googleAuthService = async (token: string) => {
     verified: true,
     googleId: payload?.sub ?? "",
     role: Role.Prospect,
+    active: true,
   })
 
   const accessToken = jwt.sign({ id: createdUser._id }, secret, {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -19,7 +19,7 @@ export const getUsersService = async (search?: object) => {
 
 export const updateUserService = async (
   id: string,
-  { name, email, verified, password, role, coach }: updateUserDto,
+  { name, email, verified, password, role, coach, active }: updateUserDto,
 ) => {
   const user = await getUserService({ _id: id })
 
@@ -46,6 +46,10 @@ export const updateUserService = async (
   if (password) {
     const hashedPassword = await hash(password, 10)
     user.password = hashedPassword
+  }
+
+  if (active !== undefined) {
+    user.active = active
   }
 
   await user.save()

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -115,7 +115,10 @@ export interface DecisionDto {
 }
 
 export type updateUserDto = Partial<
-  Pick<IUser, "name" | "email" | "verified" | "password" | "role" | "coach">
+  Pick<
+    IUser,
+    "name" | "email" | "verified" | "password" | "role" | "coach" | "active"
+  >
 >
 export interface ICohortOverviewRequest {
   cohortId?: string

--- a/src/validations/userValidation.ts
+++ b/src/validations/userValidation.ts
@@ -24,3 +24,6 @@ export const updateUserSchema = Joi.object({
     .valid(Role.Admin, Role.Coach, Role.Prospect, Role.Trainee, Role.Applicant)
     .optional(),
 })
+export const toggleActiveStatusSchema = Joi.object({
+  active: Joi.boolean().required(),
+})

--- a/src/validations/userValidation.ts
+++ b/src/validations/userValidation.ts
@@ -24,6 +24,3 @@ export const updateUserSchema = Joi.object({
     .valid(Role.Admin, Role.Coach, Role.Prospect, Role.Trainee, Role.Applicant)
     .optional(),
 })
-export const toggleActiveStatusSchema = Joi.object({
-  active: Joi.boolean().required(),
-})


### PR DESCRIPTION
## Tasks Completed
- All users/admins are active by default
- Only the admin can deactivate/re-activate another admin.
- The authentication of the deactivated admin is disabled.
- The deactivated admin can not performing any actions.
- A clear message is given when deactivated admin tries to log in. “Account is was deactivated, please consult the admin for more information”

Trello Card: https://trello.com/c/piuqJlMV/150-allow-the-admin-to-deactivate-another-admin